### PR TITLE
Fix export payload Transferable implementation

### DIFF
--- a/Culsi/Culsi/Export/ExportService.swift
+++ b/Culsi/Culsi/Export/ExportService.swift
@@ -1,6 +1,6 @@
-import CoreTransferable
 import Foundation
 import UniformTypeIdentifiers
+import CoreTransferable
 
 enum ExportError: Error {
     case encoding
@@ -58,10 +58,9 @@ struct ExportPayload: Transferable {
     let format: ExportFormat
 
     static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation(
-            exporting: ExportPayload.self,
-            contentType: \.format.utType
-        ) { payload in
+        // Use the designated initializer that takes a fixed UTType.
+        // We pass `.data` and rely on the filename extension for the correct type.
+        DataRepresentation(exportedContentType: .data) { payload in
             payload.data
         }
         .suggestedFileName { payload in


### PR DESCRIPTION
## Summary
- update ExportPayload to use the CoreTransferable `DataRepresentation` initializer with `exportedContentType`
- keep suggested file naming tied to the export format while relying on the filename extension for typing
- tidy import ordering to ensure the required Foundation, UniformTypeIdentifiers, and CoreTransferable modules are present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d33691045883228fb98db535951757