### PR TITLE
Configure test target and restore label printing layout

### DIFF
--- a/Culsi/Culsi.xcodeproj/project.pbxproj
+++ b/Culsi/Culsi.xcodeproj/project.pbxproj
@@ -13,15 +13,81 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		83A44D2E2E83468900126B17 /* Culsi */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Culsi;
-			sourceTree = "<group>";
-		};
-
-                83B1A0182E8349AB00126B17 /* CulsiTests */ = {
+                CD18FC9FB6494384932AF3BD /* App */ = {
                         isa = PBXFileSystemSynchronizedRootGroup;
-                        path = Culsi/Culsi/Tests;
+                        path = App;
+                        sourceTree = "<group>";
+                };
+
+                A6FE8102C0FA7A26774E22AF /* Assets.xcassets */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Assets.xcassets;
+                        sourceTree = "<group>";
+                };
+
+                3993A69E2CA7956518F22441 /* Culsi.xcdatamodeld */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Culsi.xcdatamodeld;
+                        sourceTree = "<group>";
+                };
+
+                2C876D8EFB2A3FA670837B5A /* Export */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Export;
+                        sourceTree = "<group>";
+                };
+
+                D1347120363C2B310653F610 /* Models */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Models;
+                        sourceTree = "<group>";
+                };
+
+                D382729BD51E13C68BF56155 /* Persistence */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Persistence;
+                        sourceTree = "<group>";
+                };
+
+                A83E50FD9BC840E2A1847FB9 /* Printing */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Printing;
+                        sourceTree = "<group>";
+                };
+
+                B49CD206A577ECD1CD15E285 /* Repositories */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Repositories;
+                        sourceTree = "<group>";
+                };
+
+                EF01FA9E1D6240CDA0600363 /* Resources */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Resources;
+                        sourceTree = "<group>";
+                };
+
+                69853FC208E384B34801168A /* Utilities */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Utilities;
+                        sourceTree = "<group>";
+                };
+
+                B1FEDB56C90448AAB2A11854 /* ViewModels */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = ViewModels;
+                        sourceTree = "<group>";
+                };
+
+                9BC493F719529CA9D33FFAA3 /* Views */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Views;
+                        sourceTree = "<group>";
+                };
+
+                83B1A0182E8349AB00126B17 /* Tests */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Tests;
                         sourceTree = "<group>";
                 };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -55,18 +121,38 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		83A44D232E83468900126B17 = {
-			isa = PBXGroup;
-			children = (
-				83A44D2E2E83468900126B17 /* Culsi */,
-				83A44D2D2E83468900126B17 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		83A44D2D2E83468900126B17 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				83A44D2C2E83468900126B17 /* Culsi.app */,
+                83A44D232E83468900126B17 = {
+                        isa = PBXGroup;
+                        children = (
+                                83A44D2E2E83468900126B17 /* Culsi */,
+                                83A44D2D2E83468900126B17 /* Products */,
+                        );
+                        sourceTree = "<group>";
+                };
+                83A44D2E2E83468900126B17 /* Culsi */ = {
+                        isa = PBXGroup;
+                        children = (
+                                CD18FC9FB6494384932AF3BD /* App */,
+                                A6FE8102C0FA7A26774E22AF /* Assets.xcassets */,
+                                3993A69E2CA7956518F22441 /* Culsi.xcdatamodeld */,
+                                2C876D8EFB2A3FA670837B5A /* Export */,
+                                D1347120363C2B310653F610 /* Models */,
+                                D382729BD51E13C68BF56155 /* Persistence */,
+                                A83E50FD9BC840E2A1847FB9 /* Printing */,
+                                B49CD206A577ECD1CD15E285 /* Repositories */,
+                                EF01FA9E1D6240CDA0600363 /* Resources */,
+                                69853FC208E384B34801168A /* Utilities */,
+                                B1FEDB56C90448AAB2A11854 /* ViewModels */,
+                                9BC493F719529CA9D33FFAA3 /* Views */,
+                                83B1A0182E8349AB00126B17 /* Tests */,
+                        );
+                        path = Culsi;
+                        sourceTree = "<group>";
+                };
+                83A44D2D2E83468900126B17 /* Products */ = {
+                        isa = PBXGroup;
+                        children = (
+                                83A44D2C2E83468900126B17 /* Culsi.app */,
                                 83B1A0172E8349AB00126B17 /* CulsiTests.xctest */,
 			);
 			name = Products;
@@ -87,9 +173,20 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-				83A44D2E2E83468900126B17 /* Culsi */,
-			);
+                        fileSystemSynchronizedGroups = (
+                                CD18FC9FB6494384932AF3BD /* App */,
+                                A6FE8102C0FA7A26774E22AF /* Assets.xcassets */,
+                                3993A69E2CA7956518F22441 /* Culsi.xcdatamodeld */,
+                                2C876D8EFB2A3FA670837B5A /* Export */,
+                                D1347120363C2B310653F610 /* Models */,
+                                D382729BD51E13C68BF56155 /* Persistence */,
+                                A83E50FD9BC840E2A1847FB9 /* Printing */,
+                                B49CD206A577ECD1CD15E285 /* Repositories */,
+                                EF01FA9E1D6240CDA0600363 /* Resources */,
+                                69853FC208E384B34801168A /* Utilities */,
+                                B1FEDB56C90448AAB2A11854 /* ViewModels */,
+                                9BC493F719529CA9D33FFAA3 /* Views */,
+                        );
 			name = Culsi;
 			packageProductDependencies = (
 			);
@@ -112,7 +209,7 @@
                                 83B1A01A2E8349AB00126B17 /* PBXTargetDependency */,
                         );
                         fileSystemSynchronizedGroups = (
-                                83B1A0182E8349AB00126B17 /* CulsiTests */,
+                                83B1A0182E8349AB00126B17 /* Tests */,
                         );
                         name = CulsiTests;
                         packageProductDependencies = (

--- a/Culsi/Culsi/Printing/LabelPrinter.swift
+++ b/Culsi/Culsi/Printing/LabelPrinter.swift
@@ -1,18 +1,93 @@
 import Foundation
 import UIKit
 
+// Minimal info needed to render a label. If you already have AveryPlacement, adapt initializer to use it.
+struct SimplePlacement {
+    let title: String
+    let subtitle: String?
+}
+
 final class LabelPrinter: UIPrintPageRenderer {
-    override init() {
+    private let placements: [SimplePlacement]
+    private let columns: Int
+    private let rows: Int
+
+    private var labelsPerPage: Int { max(1, columns * rows) }
+    private var totalPages: Int {
+        let count = placements.count
+        return max(1, Int(ceil(Double(count) / Double(labelsPerPage))))
+    }
+
+    init(placements: [SimplePlacement], columns: Int, rows: Int) {
+        self.placements = placements
+        self.columns = max(1, columns)
+        self.rows = max(1, rows)
         super.init()
+        // US Letter
         let letter = CGRect(x: 0, y: 0, width: 612, height: 792) // 8.5x11 @ 72dpi
         setValue(letter, forKey: "paperRect")
         setValue(letter.insetBy(dx: 36, dy: 36), forKey: "printableRect")
     }
+
+    override var numberOfPages: Int { totalPages }
+
     override func drawPage(at pageIndex: Int, in printableRect: CGRect) {
         guard let ctx = UIGraphicsGetCurrentContext() else { return }
         ctx.saveGState(); defer { ctx.restoreGState() }
-        let text = "Culsi Label Preview – Page \(pageIndex + 1)"
-        let attrs: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14, weight: .semibold)]
-        text.draw(in: printableRect.insetBy(dx: 12, dy: 12), withAttributes: attrs)
+
+        let cellW = printableRect.width / CGFloat(columns)
+        let cellH = printableRect.height / CGFloat(rows)
+        let start = pageIndex * labelsPerPage
+        let end = min(start + labelsPerPage, placements.count)
+
+        let titleAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 12, weight: .semibold),
+            .foregroundColor: UIColor.black
+        ]
+        let subAttrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 10),
+            .foregroundColor: UIColor.darkGray
+        ]
+
+        for r in 0..<rows {
+            for c in 0..<columns {
+                let idx = start + r * columns + c
+                let cell = CGRect(
+                    x: printableRect.minX + CGFloat(c) * cellW,
+                    y: printableRect.minY + CGFloat(r) * cellH,
+                    width: cellW, height: cellH
+                ).insetBy(dx: 6, dy: 6)
+
+                // Draw cell border (light)
+                UIColor(white: 0.85, alpha: 1).setStroke()
+                UIBezierPath(rect: cell).stroke()
+
+                guard idx < end else { continue }
+                let placement = placements[idx]
+
+                // Draw text
+                placement.title.draw(in: cell.insetBy(dx: 4, dy: 4), withAttributes: titleAttrs)
+                if let subtitle = placement.subtitle, !subtitle.isEmpty {
+                    let subRect = cell.insetBy(dx: 4, dy: 24)
+                    subtitle.draw(in: subRect, withAttributes: subAttrs)
+                }
+            }
+        }
+    }
+}
+
+extension LabelPrinter {
+    // Bridge from your real models to SimplePlacement + grid sizes.
+    static func from(placements: [AveryPlacement], sheet: AverySheetState) -> LabelPrinter {
+        // Map AveryPlacement fields to a simple title/subtitle.
+        let mapped: [SimplePlacement] = placements.map { placement in
+            let parts = placement.text.components(separatedBy: .newlines)
+            let rawTitle = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "Label"
+            let subtitleText = parts.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = rawTitle.isEmpty ? "Label" : rawTitle
+            let subtitle = subtitleText.isEmpty ? nil : subtitleText
+            return SimplePlacement(title: title, subtitle: subtitle)
+        }
+        return LabelPrinter(placements: mapped, columns: sheet.columns, rows: sheet.rows)
     }
 }

--- a/Culsi/Culsi/Views/LabelPreviewView.swift
+++ b/Culsi/Culsi/Views/LabelPreviewView.swift
@@ -39,8 +39,12 @@ struct LabelPreviewView: View {
                     }
                     Button("Print") {
                         #if canImport(UIKit)
+                        let renderer = LabelPrinter.from(
+                            placements: batchViewModel.placements,
+                            sheet: batchViewModel.sheetState
+                        )
                         let controller = UIPrintInteractionController.shared
-                        controller.printPageRenderer = LabelPrinter()
+                        controller.printPageRenderer = renderer
                         controller.present(animated: true, completionHandler: nil)
                         #endif
                     }


### PR DESCRIPTION
## Summary
- scope the app target to source-only directories and synchronize the tests folder exclusively with the CulsiTests bundle
- update LabelPrinter to render label placements across pages and expose a helper that maps Avery models
- hook up the print action to pass the current placements and sheet configuration into the renderer

## Testing
- Not run (Xcode unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3410651ac8322bd5a3a8f4e9f6a60