### PR TITLE
Fix export toolbar availability and payload

### DIFF
--- a/Culsi/Culsi/Views/FoodLogListView.swift
+++ b/Culsi/Culsi/Views/FoodLogListView.swift
@@ -1,3 +1,4 @@
+import CoreTransferable
 import SwiftUI
 
 struct FoodLogListView: View {
@@ -56,15 +57,22 @@ struct FoodLogListView: View {
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Menu {
                         ForEach(exportFormats, id: \.self) { format in
-                            if let payload = try? exportService.payload(for: viewModel.logs, format: format) {
+                            // iOS 16+ only: ShareLink requires CoreTransferable
+                            if #available(iOS 16.0, *),
+                               let payload: ExportPayload = (try? exportService.payload(for: viewModel.logs, format: format)) {
                                 ShareLink(item: payload) {
-                                    let icon = format == .csv ? "tablecells" : "curlybraces"
+                                    let icon = (format == .csv) ? "tablecells" : "curlybraces"
                                     Label("Share \(format.rawValue.uppercased())", systemImage: icon)
                                 }
+                            } else {
+                                // Fallback: disabled button on older iOS (shouldn’t hit if target is iOS 17)
+                                let icon = (format == .csv) ? "tablecells" : "curlybraces"
+                                Label("Share \(format.rawValue.uppercased())", systemImage: icon)
+                                    .foregroundStyle(.secondary)
                             }
                         }
                     } label: {
-                        Image(systemName: "square.and.arrow.up")
+                        Label("Export", systemImage: "square.and.arrow.up")
                     }
                     Button {
                         presentingCreate = true


### PR DESCRIPTION
## Summary
- import CoreTransferable in `FoodLogListView` so the export toolbar can access `Transferable`
- wrap export share actions in an iOS 16 availability check with an explicit `ExportPayload` cast
- fall back to a disabled label on older iOS versions and use a labeled export menu button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d34ded8e108322bba6c581f21fc1bb