### PR TITLE
Fix export share link typing

### DIFF
--- a/Culsi/Culsi/Export/ExportService.swift
+++ b/Culsi/Culsi/Export/ExportService.swift
@@ -51,11 +51,7 @@ struct ExportPayload: Transferable {
     let format: ExportFormat
 
     static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation(exportedContentType: .data) { payload in
-            payload.data
-        }
-        .suggestedFileName { payload in
-            "\(payload.filename).\(payload.format.fileExtension)"
-        }
+        DataRepresentation(exportedContentType: .data) { $0.data }
+            .suggestedFileName { "\($0.filename).\($0.format.fileExtension)" }
     }
 }

--- a/Culsi/Culsi/Views/FoodLogListView.swift
+++ b/Culsi/Culsi/Views/FoodLogListView.swift
@@ -1,5 +1,5 @@
-import CoreTransferable
 import SwiftUI
+import CoreTransferable
 import SwiftData
 
 struct FoodLogListView: View {
@@ -58,15 +58,13 @@ struct FoodLogListView: View {
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Menu {
                         ForEach(exportFormats, id: \.self) { format in
-                            // iOS 16+ only: ShareLink requires CoreTransferable
                             if #available(iOS 16.0, *),
                                let payload: ExportPayload = (try? exportService.payload(for: viewModel.logs, format: format)) {
-                                ShareLink(item: payload) {
+                                ShareLink(item: payload, preview: SharePreview("\(payload.filename).\(payload.format.fileExtension)")) {
                                     let icon = (format == .csv) ? "tablecells" : "curlybraces"
                                     Label("Share \(format.rawValue.uppercased())", systemImage: icon)
                                 }
                             } else {
-                                // Fallback: disabled button on older iOS (shouldn’t hit if target is iOS 17)
                                 let icon = (format == .csv) ? "tablecells" : "curlybraces"
                                 Label("Share \(format.rawValue.uppercased())", systemImage: icon)
                                     .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- ensure FoodLogListView imports SwiftUI before CoreTransferable
- update the export toolbar to use a typed ExportPayload ShareLink preview
- simplify ExportPayload transferRepresentation chaining for clearer type inference

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3503ab1708322a5f9f2c9b04675f5