### PR TITLE
Add time and temperature holding policies

### DIFF
--- a/Culsi/Culsi.xcodeproj/project.pbxproj
+++ b/Culsi/Culsi.xcodeproj/project.pbxproj
@@ -51,16 +51,21 @@
 			path = Assets.xcassets;
 			sourceTree = "<group>";
 		};
-		A83E50FD9BC840E2A1847FB9 /* Printing */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Printing;
-			sourceTree = "<group>";
-		};
-		B1FEDB56C90448AAB2A11854 /* ViewModels */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = ViewModels;
-			sourceTree = "<group>";
-		};
+                A83E50FD9BC840E2A1847FB9 /* Printing */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Printing;
+                        sourceTree = "<group>";
+                };
+                E2A5F1D9C0B842F6B9E0D123 /* Services */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = Services;
+                        sourceTree = "<group>";
+                };
+                B1FEDB56C90448AAB2A11854 /* ViewModels */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = ViewModels;
+                        sourceTree = "<group>";
+                };
 		B49CD206A577ECD1CD15E285 /* Repositories */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Repositories;
@@ -122,14 +127,15 @@
 				A6FE8102C0FA7A26774E22AF /* Assets.xcassets */,
 				3993A69E2CA7956518F22441 /* Culsi.xcdatamodeld */,
 				2C876D8EFB2A3FA670837B5A /* Export */,
-				D1347120363C2B310653F610 /* Models */,
-				D382729BD51E13C68BF56155 /* Persistence */,
-				A83E50FD9BC840E2A1847FB9 /* Printing */,
-				B49CD206A577ECD1CD15E285 /* Repositories */,
-				EF01FA9E1D6240CDA0600363 /* Resources */,
-				69853FC208E384B34801168A /* Utilities */,
-				B1FEDB56C90448AAB2A11854 /* ViewModels */,
-				9BC493F719529CA9D33FFAA3 /* Views */,
+                                D1347120363C2B310653F610 /* Models */,
+                                D382729BD51E13C68BF56155 /* Persistence */,
+                                A83E50FD9BC840E2A1847FB9 /* Printing */,
+                                B49CD206A577ECD1CD15E285 /* Repositories */,
+                                E2A5F1D9C0B842F6B9E0D123 /* Services */,
+                                EF01FA9E1D6240CDA0600363 /* Resources */,
+                                69853FC208E384B34801168A /* Utilities */,
+                                B1FEDB56C90448AAB2A11854 /* ViewModels */,
+                                9BC493F719529CA9D33FFAA3 /* Views */,
 			);
 			path = Culsi;
 			sourceTree = "<group>";
@@ -157,11 +163,12 @@
 				A6FE8102C0FA7A26774E22AF /* Assets.xcassets */,
 				A83E50FD9BC840E2A1847FB9 /* Printing */,
 				B1FEDB56C90448AAB2A11854 /* ViewModels */,
-				B49CD206A577ECD1CD15E285 /* Repositories */,
-				CD18FC9FB6494384932AF3BD /* App */,
-				D1347120363C2B310653F610 /* Models */,
-				D382729BD51E13C68BF56155 /* Persistence */,
-				EF01FA9E1D6240CDA0600363 /* Resources */,
+                                B49CD206A577ECD1CD15E285 /* Repositories */,
+                                E2A5F1D9C0B842F6B9E0D123 /* Services */,
+                                CD18FC9FB6494384932AF3BD /* App */,
+                                D1347120363C2B310653F610 /* Models */,
+                                D382729BD51E13C68BF56155 /* Persistence */,
+                                EF01FA9E1D6240CDA0600363 /* Resources */,
 			);
 			name = Culsi;
 			packageProductDependencies = (

--- a/Culsi/Culsi/Export/ExportService.swift
+++ b/Culsi/Culsi/Export/ExportService.swift
@@ -23,7 +23,7 @@ struct ExportService {
     }
 
     func csv(from logs: [FoodLog]) -> String {
-        var rows = ["id,name,date,quantity,unit,notes"]
+        var rows = ["id,name,date,quantity,unit,notes,policy,startedAt,measuredTemp,tempUnit,location,employee,expiresAt,isExpired"]
         for log in logs {
             let values = [
                 log.id.uuidString,
@@ -31,7 +31,15 @@ struct ExportService {
                 Converters.isoFormatter.string(from: log.date),
                 String(log.quantity),
                 escape(log.unit),
-                escape(log.notes ?? "")
+                escape(log.notes ?? ""),
+                log.policy.rawValue,
+                Converters.isoFormatter.string(from: log.startedAt),
+                log.measuredTemp.map { String($0) } ?? "",
+                log.tempUnit.rawValue,
+                escape(log.location ?? ""),
+                escape(log.employee ?? ""),
+                log.policy == .tphc4h ? Converters.isoFormatter.string(from: log.expiresAt) : "",
+                log.policy == .tphc4h ? String(log.isExpired) : ""
             ]
             rows.append(values.joined(separator: ","))
         }

--- a/Culsi/Culsi/Models/FoodLog.swift
+++ b/Culsi/Culsi/Models/FoodLog.swift
@@ -2,6 +2,55 @@ import Foundation
 #if canImport(SwiftData)
 import SwiftData
 
+enum HoldPolicy: String, Codable, CaseIterable, Identifiable {
+    case hotHold
+    case coldHold
+    case tphc4h
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .hotHold:
+            return "Hot Hold"
+        case .coldHold:
+            return "Cold Hold"
+        case .tphc4h:
+            return "TPHC (4h)"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .hotHold:
+            return "thermometer.sun"
+        case .coldHold:
+            return "thermometer.snowflake"
+        case .tphc4h:
+            return "timer"
+        }
+    }
+}
+
+enum MeasureUnit: String, Codable, CaseIterable, Identifiable {
+    case f
+    case c
+    case ea
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .f:
+            return "°F"
+        case .c:
+            return "°C"
+        case .ea:
+            return "ea"
+        }
+    }
+}
+
 @Model
 final class FoodLog: Identifiable, Codable {
     @Attribute(.unique) var id: UUID
@@ -9,10 +58,24 @@ final class FoodLog: Identifiable, Codable {
     var date: Date
     var quantity: Double
     var unit: String
+    var policy: HoldPolicy
+    var startedAt: Date
+    var measuredTemp: Double?
+    var tempUnit: MeasureUnit
+    var location: String?
+    var employee: String?
     var notes: String?
 
+    var expiresAt: Date {
+        policy == .tphc4h ? startedAt.addingTimeInterval(4 * 60 * 60) : startedAt
+    }
+
+    var isExpired: Bool {
+        policy == .tphc4h && Date() >= expiresAt
+    }
+
     enum CodingKeys: CodingKey {
-        case id, name, date, quantity, unit, notes
+        case id, name, date, quantity, unit, policy, startedAt, measuredTemp, tempUnit, location, employee, notes
     }
 
     init(
@@ -21,6 +84,12 @@ final class FoodLog: Identifiable, Codable {
         date: Date = .now,
         quantity: Double,
         unit: String,
+        policy: HoldPolicy,
+        startedAt: Date = .now,
+        measuredTemp: Double? = nil,
+        tempUnit: MeasureUnit = .f,
+        location: String? = nil,
+        employee: String? = nil,
         notes: String? = nil
     ) {
         self.id = id
@@ -28,6 +97,12 @@ final class FoodLog: Identifiable, Codable {
         self.date = date
         self.quantity = quantity
         self.unit = unit
+        self.policy = policy
+        self.startedAt = startedAt
+        self.measuredTemp = measuredTemp
+        self.tempUnit = tempUnit
+        self.location = location
+        self.employee = employee
         self.notes = notes
     }
 
@@ -38,6 +113,12 @@ final class FoodLog: Identifiable, Codable {
             date: input.date,
             quantity: input.quantity,
             unit: input.unit,
+            policy: input.policy,
+            startedAt: input.startedAt,
+            measuredTemp: input.measuredTemp,
+            tempUnit: input.tempUnit,
+            location: input.location,
+            employee: input.employee,
             notes: input.notes
         )
     }
@@ -49,8 +130,27 @@ final class FoodLog: Identifiable, Codable {
         let date = try container.decode(Date.self, forKey: .date)
         let quantity = try container.decode(Double.self, forKey: .quantity)
         let unit = try container.decode(String.self, forKey: .unit)
+        let policy = try container.decodeIfPresent(HoldPolicy.self, forKey: .policy) ?? .hotHold
+        let startedAt = try container.decodeIfPresent(Date.self, forKey: .startedAt) ?? date
+        let measuredTemp = try container.decodeIfPresent(Double.self, forKey: .measuredTemp)
+        let tempUnit = try container.decodeIfPresent(MeasureUnit.self, forKey: .tempUnit) ?? .f
+        let location = try container.decodeIfPresent(String.self, forKey: .location)
+        let employee = try container.decodeIfPresent(String.self, forKey: .employee)
         let notes = try container.decodeIfPresent(String.self, forKey: .notes)
-        self.init(id: id, name: name, date: date, quantity: quantity, unit: unit, notes: notes)
+        self.init(
+            id: id,
+            name: name,
+            date: date,
+            quantity: quantity,
+            unit: unit,
+            policy: policy,
+            startedAt: startedAt,
+            measuredTemp: measuredTemp,
+            tempUnit: tempUnit,
+            location: location,
+            employee: employee,
+            notes: notes
+        )
     }
 
     func encode(to encoder: Encoder) throws {
@@ -60,6 +160,12 @@ final class FoodLog: Identifiable, Codable {
         try container.encode(date, forKey: .date)
         try container.encode(quantity, forKey: .quantity)
         try container.encode(unit, forKey: .unit)
+        try container.encode(policy, forKey: .policy)
+        try container.encode(startedAt, forKey: .startedAt)
+        try container.encodeIfPresent(measuredTemp, forKey: .measuredTemp)
+        try container.encode(tempUnit, forKey: .tempUnit)
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encodeIfPresent(employee, forKey: .employee)
         try container.encodeIfPresent(notes, forKey: .notes)
     }
 }
@@ -70,6 +176,12 @@ struct FoodLogInput: Identifiable, Equatable, Codable {
     var date: Date
     var quantity: Double
     var unit: String
+    var policy: HoldPolicy
+    var startedAt: Date
+    var measuredTemp: Double?
+    var tempUnit: MeasureUnit
+    var location: String?
+    var employee: String?
     var notes: String?
 
     init(
@@ -78,6 +190,12 @@ struct FoodLogInput: Identifiable, Equatable, Codable {
         date: Date = .now,
         quantity: Double = 1,
         unit: String = "ea",
+        policy: HoldPolicy = .hotHold,
+        startedAt: Date = .now,
+        measuredTemp: Double? = nil,
+        tempUnit: MeasureUnit = .f,
+        location: String? = nil,
+        employee: String? = nil,
         notes: String? = nil
     ) {
         self.id = id
@@ -85,11 +203,30 @@ struct FoodLogInput: Identifiable, Equatable, Codable {
         self.date = date
         self.quantity = quantity
         self.unit = unit
+        self.policy = policy
+        self.startedAt = startedAt
+        self.measuredTemp = measuredTemp
+        self.tempUnit = tempUnit
+        self.location = location
+        self.employee = employee
         self.notes = notes
     }
 
     init(log: FoodLog) {
-        self.init(id: log.id, name: log.name, date: log.date, quantity: log.quantity, unit: log.unit, notes: log.notes)
+        self.init(
+            id: log.id,
+            name: log.name,
+            date: log.date,
+            quantity: log.quantity,
+            unit: log.unit,
+            policy: log.policy,
+            startedAt: log.startedAt,
+            measuredTemp: log.measuredTemp,
+            tempUnit: log.tempUnit,
+            location: log.location,
+            employee: log.employee,
+            notes: log.notes
+        )
     }
 }
 #else

--- a/Culsi/Culsi/Persistence/CulsiDatabase.swift
+++ b/Culsi/Culsi/Persistence/CulsiDatabase.swift
@@ -45,9 +45,43 @@ final class CulsiDatabase: Database {
 
             let now = dateProvider()
             let logs = [
-                FoodLog(name: "Milk", date: now, quantity: 2, unit: "L", notes: "Organic"),
-                FoodLog(name: "Eggs", date: now.addingTimeInterval(-86400), quantity: 12, unit: "ea", notes: "Farm"),
-                FoodLog(name: "Bread", date: now.addingTimeInterval(-172800), quantity: 1, unit: "loaf")
+                FoodLog(
+                    name: "Soup",
+                    date: now,
+                    quantity: 1,
+                    unit: "pan",
+                    policy: .hotHold,
+                    startedAt: now.addingTimeInterval(-1800),
+                    measuredTemp: 165,
+                    tempUnit: .f,
+                    location: "Line 1",
+                    employee: "AB",
+                    notes: "Stir hourly"
+                ),
+                FoodLog(
+                    name: "Salad",
+                    date: now.addingTimeInterval(-86400),
+                    quantity: 3,
+                    unit: "tray",
+                    policy: .coldHold,
+                    startedAt: now.addingTimeInterval(-7200),
+                    measuredTemp: 41,
+                    tempUnit: .f,
+                    location: "Salad Bar",
+                    employee: "CD",
+                    notes: "Keep covered"
+                ),
+                FoodLog(
+                    name: "Pizza",
+                    date: now.addingTimeInterval(-172800),
+                    quantity: 10,
+                    unit: "slice",
+                    policy: .tphc4h,
+                    startedAt: now.addingTimeInterval(-3000),
+                    measuredTemp: nil,
+                    tempUnit: .f,
+                    location: "Grab & Go"
+                )
             ]
             logs.forEach { context.insert($0) }
 

--- a/Culsi/Culsi/Persistence/FoodLogStore.swift
+++ b/Culsi/Culsi/Persistence/FoodLogStore.swift
@@ -20,19 +20,21 @@ actor FoodLogStore {
     }
 
     func fetchLogs(matching query: FoodLogQuery = FoodLogQuery()) throws -> [FoodLog] {
-        var descriptor = FetchDescriptor<FoodLog>(sortBy: [SortDescriptor(\FoodLog.date, order: .reverse)])
+        var descriptor = FetchDescriptor<FoodLog>(sortBy: [SortDescriptor(\FoodLog.startedAt, order: .reverse)])
         descriptor.fetchLimit = nil
         let results = try context.fetch(descriptor)
         guard query.searchText != nil || query.startDate != nil || query.endDate != nil else {
             return results
         }
         return results.filter { log in
-            if let startDate = query.startDate, log.date < startDate { return false }
-            if let endDate = query.endDate, log.date > endDate { return false }
+            if let startDate = query.startDate, log.startedAt < startDate { return false }
+            if let endDate = query.endDate, log.startedAt > endDate { return false }
             if let search = query.searchText?.trimmingCharacters(in: .whitespacesAndNewlines), !search.isEmpty {
                 let matchesName = log.name.localizedCaseInsensitiveContains(search)
+                let matchesLocation = (log.location ?? "").localizedCaseInsensitiveContains(search)
+                let matchesEmployee = (log.employee ?? "").localizedCaseInsensitiveContains(search)
                 let matchesNotes = (log.notes ?? "").localizedCaseInsensitiveContains(search)
-                if !(matchesName || matchesNotes) { return false }
+                if !(matchesName || matchesNotes || matchesLocation || matchesEmployee) { return false }
             }
             return true
         }
@@ -55,6 +57,12 @@ actor FoodLogStore {
         existing.date = input.date
         existing.quantity = input.quantity
         existing.unit = input.unit
+        existing.policy = input.policy
+        existing.startedAt = input.startedAt
+        existing.measuredTemp = input.measuredTemp
+        existing.tempUnit = input.tempUnit
+        existing.location = input.location
+        existing.employee = input.employee
         existing.notes = input.notes
         try context.save()
         return existing
@@ -66,6 +74,33 @@ actor FoodLogStore {
         }
         context.delete(existing)
         try context.save()
+    }
+
+    func fetchActiveTPHC() throws -> [FoodLog] {
+        try fetchTPHCLogs().filter { !$0.isExpired }
+    }
+
+    func fetchExpiredTPHC() throws -> [FoodLog] {
+        try fetchTPHCLogs().filter(\.isExpired)
+    }
+
+    @discardableResult
+    func updateTemperature(id: UUID, measuredTemp: Double?, unit: MeasureUnit) throws -> FoodLog {
+        guard let existing = try context.fetch(FetchDescriptor<FoodLog>(predicate: #Predicate { $0.id == id })).first else {
+            throw FoodLogStoreError.notFound
+        }
+        existing.measuredTemp = measuredTemp
+        existing.tempUnit = unit
+        try context.save()
+        return existing
+    }
+
+    private func fetchTPHCLogs() throws -> [FoodLog] {
+        let descriptor = FetchDescriptor<FoodLog>(
+            predicate: #Predicate { $0.policy == .tphc4h },
+            sortBy: [SortDescriptor(\FoodLog.startedAt, order: .reverse)]
+        )
+        return try context.fetch(descriptor)
     }
 }
 #else

--- a/Culsi/Culsi/Printing/LabelPrinter.swift
+++ b/Culsi/Culsi/Printing/LabelPrinter.swift
@@ -91,3 +91,26 @@ extension LabelPrinter {
         return LabelPrinter(placements: mapped, columns: sheet.columns, rows: sheet.rows)
     }
 }
+
+extension LabelPrinter {
+    static func from(foodLogs: [FoodLog]) -> LabelPrinter {
+        let df = DateFormatter()
+        df.timeStyle = .short
+        let placements = foodLogs.map { log in
+            let subtitle: String = {
+                switch log.policy {
+                case .tphc4h:
+                    return "Start: \(df.string(from: log.startedAt))  Discard: \(df.string(from: log.expiresAt))"
+                case .hotHold, .coldHold:
+                    if let t = log.measuredTemp {
+                        let unit = log.tempUnit == .f ? "°F" : "°C"
+                        return "Temp: \(Int(t.rounded()))\(unit)"
+                    }
+                    return ""
+                }
+            }()
+            return SimplePlacement(title: log.name, subtitle: subtitle)
+        }
+        return LabelPrinter(placements: placements, columns: 3, rows: 10)
+    }
+}

--- a/Culsi/Culsi/Repositories/FoodLogRepository.swift
+++ b/Culsi/Culsi/Repositories/FoodLogRepository.swift
@@ -3,20 +3,35 @@ import Foundation
 
 protocol FoodLogRepositoryType {
     var logsPublisher: AnyPublisher<[FoodLog], Never> { get }
+    var activeTPHCPublisher: AnyPublisher<[FoodLog], Never> { get }
+    var expiredTPHCPublisher: AnyPublisher<[FoodLog], Never> { get }
     func setQuery(_ query: FoodLogQuery) async
     func refresh() async
     func add(_ new: FoodLogInput) async throws
     func update(_ log: FoodLog) async throws
     func delete(id: UUID) async throws
+    func fetchActiveTPHC() async -> [FoodLog]
+    func fetchExpiredTPHC() async -> [FoodLog]
+    func updateTemperature(id: UUID, measuredTemp: Double?, unit: MeasureUnit) async throws
 }
 
 final class FoodLogRepository: FoodLogRepositoryType {
     private let store: FoodLogStore
     private let subject = CurrentValueSubject<[FoodLog], Never>([])
+    private let activeTPHCSubject = CurrentValueSubject<[FoodLog], Never>([])
+    private let expiredTPHCSubject = CurrentValueSubject<[FoodLog], Never>([])
     private var query = FoodLogQuery()
 
     var logsPublisher: AnyPublisher<[FoodLog], Never> {
         subject.eraseToAnyPublisher()
+    }
+
+    var activeTPHCPublisher: AnyPublisher<[FoodLog], Never> {
+        activeTPHCSubject.eraseToAnyPublisher()
+    }
+
+    var expiredTPHCPublisher: AnyPublisher<[FoodLog], Never> {
+        expiredTPHCSubject.eraseToAnyPublisher()
     }
 
     init(store: FoodLogStore = FoodLogStore()) {
@@ -33,11 +48,14 @@ final class FoodLogRepository: FoodLogRepositoryType {
         do {
             let logs = try await store.fetchLogs(matching: query)
             subject.send(logs)
+            try await updateTPHCStates()
         } catch {
             #if DEBUG
             print("Failed to fetch logs: \(error)")
             #endif
             subject.send([])
+            activeTPHCSubject.send([])
+            expiredTPHCSubject.send([])
         }
     }
 
@@ -56,5 +74,25 @@ final class FoodLogRepository: FoodLogRepositoryType {
     func delete(id: UUID) async throws {
         try await store.delete(id: id)
         await refresh()
+    }
+
+    func fetchActiveTPHC() async -> [FoodLog] {
+        (try? await store.fetchActiveTPHC()) ?? []
+    }
+
+    func fetchExpiredTPHC() async -> [FoodLog] {
+        (try? await store.fetchExpiredTPHC()) ?? []
+    }
+
+    func updateTemperature(id: UUID, measuredTemp: Double?, unit: MeasureUnit) async throws {
+        _ = try await store.updateTemperature(id: id, measuredTemp: measuredTemp, unit: unit)
+        await refresh()
+    }
+
+    private func updateTPHCStates() async throws {
+        let active = try await store.fetchActiveTPHC()
+        let expired = try await store.fetchExpiredTPHC()
+        activeTPHCSubject.send(active)
+        expiredTPHCSubject.send(expired)
     }
 }

--- a/Culsi/Culsi/Services/TPHCService.swift
+++ b/Culsi/Culsi/Services/TPHCService.swift
@@ -1,0 +1,29 @@
+import Combine
+import Foundation
+
+final class TPHCService {
+    private var cancellable: AnyCancellable?
+    private let repository: FoodLogRepositoryType
+    private let interval: TimeInterval
+
+    init(repository: FoodLogRepositoryType, interval: TimeInterval = 30) {
+        self.repository = repository
+        self.interval = interval
+    }
+
+    func start() {
+        guard cancellable == nil else { return }
+        cancellable = Timer.publish(every: interval, on: .main, in: .common)
+            .autoconnect()
+            .prepend(Date())
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { await self.repository.refresh() }
+            }
+    }
+
+    func stop() {
+        cancellable?.cancel()
+        cancellable = nil
+    }
+}

--- a/Culsi/Culsi/ViewModels/FoodLogViewModel.swift
+++ b/Culsi/Culsi/ViewModels/FoodLogViewModel.swift
@@ -40,19 +40,28 @@ final class FoodLogViewModel: ObservableObject {
     }
 
     @Published private(set) var logs: [FoodLog] = []
+    @Published private(set) var displayedLogs: [FoodLog] = []
     @Published var searchText: String = ""
     @Published var selectedFilter: DateFilter = .all
+    @Published var filter: HoldPolicy? = nil
+    @Published var showExpired = false
+    @Published var selectedLogIDs: Set<UUID> = []
 
     private let repository: FoodLogRepositoryType
+    private let tphcService: TPHCService
     private var cancellables = Set<AnyCancellable>()
 
     init(repository: FoodLogRepositoryType = FoodLogRepository()) {
         self.repository = repository
+        self.tphcService = TPHCService(repository: repository)
 
         repository.logsPublisher
             .receive(on: RunLoop.main)
             .sink { [weak self] logs in
-                self?.logs = logs
+                guard let self else { return }
+                self.logs = logs
+                let validIDs = Set(logs.map(\.id))
+                self.selectedLogIDs = self.selectedLogIDs.intersection(validIDs)
             }
             .store(in: &cancellables)
 
@@ -71,25 +80,30 @@ final class FoodLogViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        Publishers.CombineLatest3($logs, $filter, $showExpired)
+            .map { logs, filter, showExpired in
+                FoodLogViewModel.filterLogs(logs, policy: filter, showExpired: showExpired)
+            }
+            .receive(on: RunLoop.main)
+            .assign(to: & $displayedLogs)
+
         Task { await repository.refresh() }
     }
 
     func add(_ input: FoodLogInput) {
         Task {
-            try? await repository.add(input)
+            var payload = input
+            payload.date = input.startedAt
+            try? await repository.add(payload)
         }
     }
 
     func update(id: UUID, with input: FoodLogInput) {
-        let updated = FoodLog(
-            id: id,
-            name: input.name,
-            date: input.date,
-            quantity: input.quantity,
-            unit: input.unit,
-            notes: input.notes
-        )
         Task {
+            var payload = input
+            payload.id = id
+            payload.date = input.startedAt
+            let updated = FoodLog(input: payload)
             try? await repository.update(updated)
         }
     }
@@ -98,6 +112,24 @@ final class FoodLogViewModel: ObservableObject {
         Task {
             try? await repository.delete(id: id)
         }
+    }
+
+    func updateTemperature(id: UUID, measuredTemp: Double?, unit: MeasureUnit) {
+        Task {
+            try? await repository.updateTemperature(id: id, measuredTemp: measuredTemp, unit: unit)
+        }
+    }
+
+    func onAppear() {
+        tphcService.start()
+    }
+
+    func onDisappear() {
+        tphcService.stop()
+    }
+
+    var logsSelection: [FoodLog] {
+        logs.filter { selectedLogIDs.contains($0.id) }
     }
 
     private func applyFilters() async {
@@ -110,5 +142,18 @@ final class FoodLogViewModel: ObservableObject {
             query.endDate = interval.end
         }
         await repository.setQuery(query)
+    }
+
+    private static func filterLogs(_ logs: [FoodLog], policy: HoldPolicy?, showExpired: Bool) -> [FoodLog] {
+        if showExpired {
+            return logs.filter { $0.policy == .tphc4h && $0.isExpired }
+        }
+        guard let policy else { return logs }
+        switch policy {
+        case .tphc4h:
+            return logs.filter { $0.policy == .tphc4h && !$0.isExpired }
+        case .hotHold, .coldHold:
+            return logs.filter { $0.policy == policy }
+        }
     }
 }

--- a/Culsi/Culsi/Views/FoodLogDetailView.swift
+++ b/Culsi/Culsi/Views/FoodLogDetailView.swift
@@ -13,6 +13,14 @@ struct FoodLogDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var input: FoodLogInput
 
+    private let temperatureUnits: [MeasureUnit] = MeasureUnit.allCases.filter { $0 != .ea }
+    private static let countdownFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
     init(mode: Mode, onSave: @escaping (FoodLogInput) -> Void, onDelete: (() -> Void)? = nil) {
         self.mode = mode
         self.onSave = onSave
@@ -28,16 +36,10 @@ struct FoodLogDetailView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Details") {
-                    TextField("Name", text: $input.name)
-                    DatePicker("Date", selection: $input.date, displayedComponents: .date)
-                    Stepper(value: $input.quantity, in: 0.0...999, step: 0.5) {
-                        Text("Quantity: \(input.quantity, specifier: "%.1f")")
-                    }
-                    TextField("Unit", text: $input.unit)
-                    TextField("Notes", text: $input.notes.orEmpty, axis: .vertical)
-                        .lineLimit(2...4)
-                }
+                detailsSection
+                holdingSection
+                notesSection
+
                 if mode.isEditing, let onDelete {
                     Section {
                         Button(role: .destructive) {
@@ -65,7 +67,102 @@ struct FoodLogDetailView: View {
                     .disabled(input.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
+            .onChange(of: input.policy) { newPolicy in
+                guard case .create = mode else { return }
+                if newPolicy == .tphc4h {
+                    input.startedAt = Date()
+                }
+            }
         }
+    }
+
+    private var detailsSection: some View {
+        Section("Details") {
+            TextField("Name", text: $input.name)
+            Stepper(value: $input.quantity, in: 0.0...999, step: 0.5) {
+                Text("Quantity: \(input.quantity, specifier: "%.1f")")
+            }
+            TextField("Unit", text: $input.unit)
+            Picker("Policy", selection: $input.policy) {
+                ForEach(HoldPolicy.allCases) { policy in
+                    Text(policy.title).tag(policy)
+                }
+            }
+            .pickerStyle(.menu)
+        }
+    }
+
+    private var holdingSection: some View {
+        Section("Holding") {
+            DatePicker("Start", selection: $input.startedAt, displayedComponents: [.date, .hourAndMinute])
+            if input.policy == .tphc4h {
+                HStack {
+                    Label("Discard", systemImage: "timer")
+                    Spacer()
+                    Text(discardTimeString)
+                        .foregroundStyle(input.isExpired ? Color.red : .primary)
+                }
+                if mode.isEditing {
+                    TimelineView(.periodic(from: .now, by: 30)) { context in
+                        let remaining = max(0, input.startedAt.addingTimeInterval(4 * 60 * 60).timeIntervalSince(context.date))
+                        let message: String
+                        if remaining > 0 {
+                            let value = Self.countdownFormatter.string(from: remaining) ?? "--"
+                            message = "Discard in \(value)"
+                        } else {
+                            message = "Expired"
+                        }
+                        Text(message)
+                            .font(.caption)
+                            .foregroundStyle(remaining > 0 ? Color.blue : .red)
+                    }
+                }
+            }
+            temperatureField
+            Picker("Unit", selection: $input.tempUnit) {
+                ForEach(temperatureUnits) { unit in
+                    Text(unit.title).tag(unit)
+                }
+            }
+            .pickerStyle(.segmented)
+            TextField("Location", text: $input.location.orEmpty)
+            TextField("Employee", text: $input.employee.orEmpty)
+        }
+    }
+
+    private var notesSection: some View {
+        Section("Notes") {
+            TextField("Notes", text: $input.notes.orEmpty, axis: .vertical)
+                .lineLimit(3...6)
+        }
+    }
+
+    private var temperatureField: some View {
+        TextField("Temperature", text: Binding(
+            get: {
+                if let value = input.measuredTemp {
+                    return String(format: "%.0f", value)
+                }
+                return ""
+            },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    input.measuredTemp = nil
+                } else if let value = Double(trimmed) {
+                    input.measuredTemp = value
+                }
+            }
+        ))
+        .keyboardType(.decimalPad)
+    }
+
+    private var discardTimeString: String {
+        let discardDate = input.startedAt.addingTimeInterval(4 * 60 * 60)
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter.string(from: discardDate)
     }
 }
 
@@ -80,6 +177,12 @@ private extension FoodLogDetailView.Mode {
     var isEditing: Bool {
         if case .edit = self { return true }
         return false
+    }
+}
+
+private extension FoodLogInput {
+    var isExpired: Bool {
+        policy == .tphc4h && Date() >= startedAt.addingTimeInterval(4 * 60 * 60)
     }
 }
 

--- a/Culsi/Culsi/Views/FoodLogListView.swift
+++ b/Culsi/Culsi/Views/FoodLogListView.swift
@@ -3,6 +3,26 @@ import CoreTransferable
 import SwiftData
 
 struct FoodLogListView: View {
+    private enum PolicyFilter: String, CaseIterable, Identifiable {
+        case all
+        case tphc
+        case hot
+        case cold
+        case expired
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .all: return "All"
+            case .tphc: return "TPHC"
+            case .hot: return "Hot Hold"
+            case .cold: return "Cold Hold"
+            case .expired: return "Expired"
+            }
+        }
+    }
+
     @StateObject private var viewModel = FoodLogViewModel()
     @State private var presentingCreate = false
     @State private var editingLog: FoodLog?
@@ -12,37 +32,32 @@ struct FoodLogListView: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(viewModel.logs) { log in
-                    Button {
-                        editingLog = log
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(log.name)
-                                    .font(.headline)
-                                Text(log.date.formatted(date: .abbreviated, time: .omitted))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                if let notes = log.notes, !notes.isEmpty {
-                                    Text(notes)
-                                        .font(.footnote)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(2)
-                                }
-                            }
-                            Spacer()
-                            Text(String(format: "%.2f %@", log.quantity, log.unit))
-                                .font(.callout)
-                                .foregroundStyle(.secondary)
+                Section {
+                    Picker("Policy Filter", selection: policyFilterBinding) {
+                        ForEach(PolicyFilter.allCases) { filter in
+                            Text(filter.title).tag(filter)
                         }
                     }
-                    .buttonStyle(.plain)
+                    .pickerStyle(.segmented)
                 }
-                .onDelete(perform: delete)
+
+                Section {
+                    ForEach(viewModel.displayedLogs) { log in
+                        Button {
+                            editingLog = log
+                        } label: {
+                            FoodLogRow(log: log)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onDelete(perform: delete)
+                }
             }
             .listStyle(.insetGrouped)
             .navigationTitle("Food Log")
             .searchable(text: $viewModel.searchText)
+            .onAppear { viewModel.onAppear() }
+            .onDisappear { viewModel.onDisappear() }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Menu {
@@ -97,9 +112,46 @@ struct FoodLogListView: View {
 
     private func delete(at offsets: IndexSet) {
         for index in offsets {
-            let log = viewModel.logs[index]
+            let log = viewModel.displayedLogs[index]
             viewModel.delete(id: log.id)
         }
+    }
+
+    private var policyFilterBinding: Binding<PolicyFilter> {
+        Binding<PolicyFilter>(
+            get: {
+                if viewModel.showExpired { return .expired }
+                switch viewModel.filter {
+                case .none:
+                    return .all
+                case .some(.tphc4h):
+                    return .tphc
+                case .some(.hotHold):
+                    return .hot
+                case .some(.coldHold):
+                    return .cold
+                }
+            },
+            set: { selection in
+                switch selection {
+                case .all:
+                    viewModel.filter = nil
+                    viewModel.showExpired = false
+                case .tphc:
+                    viewModel.filter = .tphc4h
+                    viewModel.showExpired = false
+                case .hot:
+                    viewModel.filter = .hotHold
+                    viewModel.showExpired = false
+                case .cold:
+                    viewModel.filter = .coldHold
+                    viewModel.showExpired = false
+                case .expired:
+                    viewModel.filter = .tphc4h
+                    viewModel.showExpired = true
+                }
+            }
+        )
     }
 }
 
@@ -107,5 +159,111 @@ struct FoodLogListView_Previews: PreviewProvider {
     static var previews: some View {
         FoodLogListView()
             .modelContainer(CulsiDatabase.shared.container)
+    }
+}
+
+private struct FoodLogRow: View {
+    let log: FoodLog
+
+    private static let countdownFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    private static let startedFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: log.policy.systemImage)
+                .font(.title3)
+                .foregroundStyle(iconColor)
+                .padding(.top, 4)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(log.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    if log.policy == .tphc4h, log.isExpired {
+                        Text("Expired")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.red.opacity(0.15))
+                            .foregroundStyle(.red)
+                            .clipShape(Capsule())
+                    }
+                }
+
+                Text(log.policy.title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Text("Start: \(Self.startedFormatter.string(from: log.startedAt))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if log.policy == .tphc4h {
+                    Text(tphcCountdownText)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(log.isExpired ? Color.red : .blue)
+                } else if let measured = log.measuredTemp {
+                    Text("Temp: \(Int(measured.rounded()))\(log.tempUnit.title)")
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                }
+
+                if let location = log.location, !location.isEmpty {
+                    Text("Location: \(location)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let employee = log.employee, !employee.isEmpty {
+                    Text("Employee: \(employee)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let notes = log.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var iconColor: Color {
+        if log.policy == .tphc4h && log.isExpired { return .red }
+        switch log.policy {
+        case .hotHold:
+            return .orange
+        case .coldHold:
+            return .blue
+        case .tphc4h:
+            return .green
+        }
+    }
+
+    private var tphcCountdownText: String {
+        let remaining = max(0, log.expiresAt.timeIntervalSinceNow)
+        if remaining == 0 || log.isExpired {
+            let discardTime = Self.startedFormatter.string(from: log.expiresAt)
+            return "Discard at: \(discardTime)"
+        }
+        let formatted = Self.countdownFormatter.string(from: remaining) ?? "--"
+        return "Discard in: \(formatted)"
     }
 }

--- a/Culsi/Culsi/Views/LabelPreviewView.swift
+++ b/Culsi/Culsi/Views/LabelPreviewView.swift
@@ -13,12 +13,11 @@ struct LabelPreviewView: View {
             VStack(spacing: 16) {
                 labelGrid
                 Button("Generate from Selected Logs") {
-                    let selectedLogs = foodLogViewModel.logs.filter { batchViewModel.selectedLogs.contains($0.id) }
-                    batchViewModel.generatePlacements(from: selectedLogs)
+                    batchViewModel.generatePlacements(from: foodLogViewModel.logsSelection)
                 }
                 .buttonStyle(.borderedProminent)
 
-                List(selection: $batchViewModel.selectedLogs) {
+                List(selection: $foodLogViewModel.selectedLogIDs) {
                     ForEach(foodLogViewModel.logs) { log in
                         VStack(alignment: .leading) {
                             Text(log.name)
@@ -32,6 +31,12 @@ struct LabelPreviewView: View {
             }
             .padding()
             .navigationTitle("Labels")
+            .onAppear {
+                foodLogViewModel.onAppear()
+            }
+            .onDisappear {
+                foodLogViewModel.onDisappear()
+            }
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button("Preview") {
@@ -39,10 +44,16 @@ struct LabelPreviewView: View {
                     }
                     Button("Print") {
                         #if canImport(UIKit)
-                        let renderer = LabelPrinter.from(
-                            placements: batchViewModel.placements,
-                            sheet: batchViewModel.sheetState
-                        )
+                        let renderer: LabelPrinter
+                        let selectedLogs = foodLogViewModel.logsSelection
+                        if !selectedLogs.isEmpty {
+                            renderer = LabelPrinter.from(foodLogs: selectedLogs)
+                        } else {
+                            renderer = LabelPrinter.from(
+                                placements: batchViewModel.placements,
+                                sheet: batchViewModel.sheetState
+                            )
+                        }
                         let controller = UIPrintInteractionController.shared
                         controller.printPageRenderer = renderer
                         controller.present(animated: true, completionHandler: nil)

--- a/readme.md
+++ b/readme.md
@@ -4,11 +4,14 @@ Culsi iOS is the iOS version of the **Culsi app**, a nutrition and labeling tool
 This project is a **SwiftUI + Combine** port of the existing Culsi Android codebase (originally written in Kotlin with Room & ViewModels).
 
 ## 🚀 Features
-- Track and manage **food logs**  
-- Maintain an **item catalog**  
-- Generate and preview **Avery sheet labels**  
-- Print labels via **LabelPrinter integration**  
-- Export logs in multiple **formats** (CSV, JSON, etc.)  
+- Track and manage **food logs**
+- Maintain an **item catalog**
+- Generate and preview **Avery sheet labels**
+- Print labels via **LabelPrinter integration**
+- Export logs in multiple **formats** (CSV, JSON, etc.)
+- TPHC (4-hour) timers with live countdown and expiration
+- Hot/Cold hold logging with temperature capture
+- Labels include discard time (TPHC) or latest temperature
 
 ## 📸 Screenshots
 > _Add screenshots here once the UI is ready_


### PR DESCRIPTION
## Summary
- extend the FoodLog model and persistence layers with holding policies, temperature metadata, and TPHC expiry helpers
- add a timer-driven TPHC service plus repository/view-model publishers so the list and detail views surface live countdowns with new filters and form fields
- update exports, label printing, and README copy to reflect discard times and captured temperatures

## Testing
- `xcodebuild -list -project Culsi/Culsi.xcodeproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3579648648322b7899e4db6eccdce