### PR TITLE
Fix SwiftData TPHC predicate

### DIFF
--- a/Culsi/Culsi/Persistence/FoodLogStore.swift
+++ b/Culsi/Culsi/Persistence/FoodLogStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-#if canImport(SwiftData)
 import SwiftData
 
 struct FoodLogQuery: Equatable {
@@ -97,12 +96,11 @@ actor FoodLogStore {
 
     private func fetchTPHCLogs() throws -> [FoodLog] {
         let descriptor = FetchDescriptor<FoodLog>(
-            predicate: #Predicate { $0.policy == .tphc4h },
+            predicate: #Predicate<FoodLog> { log in
+                log.policy == HoldPolicy.tphc4h
+            },
             sortBy: [SortDescriptor(\FoodLog.startedAt, order: .reverse)]
         )
         return try context.fetch(descriptor)
     }
 }
-#else
-// Core Data fallback can be implemented if SwiftData is unavailable.
-#endif


### PR DESCRIPTION
## Summary
- import SwiftData directly in FoodLogStore to ensure the module is available
- update the TPHC fetch predicate to reference the HoldPolicy enum explicitly so the SwiftData fetch compiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3e13696688322999dd93dc500f094