### PR TITLE
Use HoldPolicy raw values in SwiftData predicates

### DIFF
--- a/Culsi/Culsi/Persistence/FoodLogStore.swift
+++ b/Culsi/Culsi/Persistence/FoodLogStore.swift
@@ -95,9 +95,10 @@ actor FoodLogStore {
     }
 
     private func fetchTPHCLogs() throws -> [FoodLog] {
+        let targetPolicy = HoldPolicy.tphc4h.rawValue
         let descriptor = FetchDescriptor<FoodLog>(
             predicate: #Predicate<FoodLog> { log in
-                log.policy == HoldPolicy.tphc4h
+                log.policy.rawValue == targetPolicy
             },
             sortBy: [SortDescriptor(\FoodLog.startedAt, order: .reverse)]
         )


### PR DESCRIPTION
## Summary
- update the TPHC fetch predicate to compare the HoldPolicy raw value instead of the enum case

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3e3a202408322b9ba199be3d68cfb