### PR TITLE
Improve holding section view builder and temperature unit picker

### DIFF
--- a/Culsi/Culsi/Models/FoodLog.swift
+++ b/Culsi/Culsi/Models/FoodLog.swift
@@ -32,13 +32,13 @@ enum HoldPolicy: String, Codable, CaseIterable, Identifiable {
     }
 }
 
-enum MeasureUnit: String, Codable, CaseIterable, Identifiable {
+enum MeasureUnit: String, Codable, CaseIterable, Hashable {
     case f
     case c
     case ea
+}
 
-    var id: String { rawValue }
-
+extension MeasureUnit {
     var title: String {
         switch self {
         case .f:


### PR DESCRIPTION
## Summary
- mark the holding section as a view builder and move the countdown timeline into a helper
- make the temperature unit enum hashable and update the picker to iterate all cases with matching tags

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ed0d344c83228e86b452173b932c