### PR TITLE
Add SwiftData fallback when persistent store fails

### DIFF
--- a/Culsi/Culsi/Persistence/CulsiDatabase.swift
+++ b/Culsi/Culsi/Persistence/CulsiDatabase.swift
@@ -14,16 +14,29 @@ final class CulsiDatabase: Database {
     let container: ModelContainer
 
     init(inMemory: Bool = false) {
+        let schema = Schema([
+            FoodLog.self,
+            CatalogItem.self,
+            AverySheetState.self
+        ])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: inMemory)
+
         do {
-            let schema = Schema([
-                FoodLog.self,
-                CatalogItem.self,
-                AverySheetState.self
-            ])
-            let configuration = ModelConfiguration(isStoredInMemoryOnly: inMemory)
             container = try ModelContainer(for: schema, configurations: configuration)
         } catch {
-            fatalError("Unable to bootstrap database: \(error)")
+            assertionFailure("Unable to bootstrap persistent database: \(error)")
+
+            guard !inMemory else {
+                fatalError("Unable to bootstrap database: \(error)")
+            }
+
+            let fallbackConfiguration = ModelConfiguration(isStoredInMemoryOnly: true)
+
+            do {
+                container = try ModelContainer(for: schema, configurations: fallbackConfiguration)
+            } catch {
+                fatalError("Unable to bootstrap fallback database: \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update the CulsiDatabase initializer to reuse the schema outside the error handling block
- add a fallback in-memory SwiftData container when the persistent store cannot be loaded
- keep the existing fatal error for repeated failures while recording an assertion for diagnostics

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3f42542508322aef126636001574a