### PR TITLE
Fix TPHC fetch predicate to use stored policy

### DIFF
--- a/Culsi/Culsi/Models/FoodLog.swift
+++ b/Culsi/Culsi/Models/FoodLog.swift
@@ -58,7 +58,7 @@ final class FoodLog: Identifiable, Codable {
     var date: Date
     var quantity: Double
     var unit: String
-    @Attribute(originalName: "policy") private var policyStorage: String?
+    @Attribute(originalName: "policy") private(set) var policyStorage: String?
     @Attribute(originalName: "tempUnit") private var tempUnitStorage: String?
     var policy: HoldPolicy {
         get {

--- a/Culsi/Culsi/Persistence/FoodLogStore.swift
+++ b/Culsi/Culsi/Persistence/FoodLogStore.swift
@@ -99,7 +99,7 @@ actor FoodLogStore {
         let targetPolicy = HoldPolicy.tphc4h.rawValue
         let descriptor = FetchDescriptor<FoodLog>(
             predicate: #Predicate<FoodLog> { log in
-                log.policy.rawValue == targetPolicy
+                log.policyStorage == targetPolicy
             },
             sortBy: [SortDescriptor(\FoodLog.startedAt, order: .reverse)]
         )


### PR DESCRIPTION
## Summary
- expose the stored policy attribute for read access so it can back predicates
- update the TPHC fetch descriptor to filter on the persisted policy raw value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d40e7291cc8322ade20b821fd744e7